### PR TITLE
Support encoding message payload passed as a pointer

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -86,6 +86,9 @@ func (e *Encoder) Encode(v interface{}) (err error) {
 func (e *Encoder) encodeValue(f field, rt reflect.Type, rv reflect.Value) (err error) {
 	if rv.Kind() == reflect.Interface && !rv.IsNil() {
 		rv = rv.Elem()
+		if rv.Kind() == reflect.Ptr {
+			rv = rv.Elem()
+		}
 		rt = rv.Type()
 
 		switch rt {

--- a/encode_test.go
+++ b/encode_test.go
@@ -205,6 +205,30 @@ func (s *EncoderSuite) TestEncodeMessageGet() {
 	s.Assert().EqualValues(messageGet, buf.Bytes())
 }
 
+func (s *EncoderSuite) TestEncodeMessageGetPointer() {
+	var buf bytes.Buffer
+
+	getRequest := Request{
+		Header: RequestHeader{
+			Version:    ProtocolVersion{Major: 1, Minor: 1},
+			BatchCount: 1,
+		},
+		BatchItems: []RequestBatchItem{
+			{
+				Operation: OPERATION_GET,
+				RequestPayload: &GetRequest{
+					UniqueIdentifier: "49a1ca88-6bea-4fb2-b450-7e58802c3038",
+				},
+			},
+		},
+	}
+
+	err := NewEncoder(&buf).Encode(&getRequest)
+	s.Assert().NoError(err)
+
+	s.Assert().EqualValues(messageGet, buf.Bytes())
+}
+
 func TestEncoderSuite(t *testing.T) {
 	suite.Run(t, new(EncoderSuite))
 }


### PR DESCRIPTION
This will allow passing payload messages as pointers to the `client.Send(...)` method like:
```
	resp, err := client.Send(kmip.OPERATION_ENCRYPT,
		&kmip.EncryptRequest{
			UniqueIdentifier: keyID,
			CryptoParams: kmip.CryptoParams{
				CryptographicAlgorithm: kmip.CRYPTO_AES,
				BlockCipherMode:        kmip.BLOCK_MODE_CBC,
				PaddingMethod:          kmip.PADDING_METHOD_PKCS_5,
			},
			Data: plaintext,
		})
	if err != nil {
		return nil, err
	}
```